### PR TITLE
[lspgen] Add default initializers for struct fields

### DIFF
--- a/lspgen/lspgen.cpp
+++ b/lspgen/lspgen.cpp
@@ -1616,6 +1616,13 @@ private:
 
 			if(!literalValue.empty())
 				m_typesHeaderFileContent += " = " + literalValue;
+			// Provide default initializer for optional values
+			else if (p.isOptional) {
+				if(!p.type->isA<ReferenceType>() || !m_typesBeingProcessed.contains(p.type->as<ReferenceType>().name))
+					m_typesHeaderFileContent += " = std::nullopt";
+				else
+					m_typesHeaderFileContent += " = nullptr";
+			}
 
 			m_typesHeaderFileContent += ";\n";
 

--- a/lspgen/lspgen.cpp
+++ b/lspgen/lspgen.cpp
@@ -1617,12 +1617,9 @@ private:
 			if(!literalValue.empty())
 				m_typesHeaderFileContent += " = " + literalValue;
 			// Provide default initializer for optional values
-			else if (p.isOptional) {
-				if(!p.type->isA<ReferenceType>() || !m_typesBeingProcessed.contains(p.type->as<ReferenceType>().name))
-					m_typesHeaderFileContent += " = std::nullopt";
-				else
-					m_typesHeaderFileContent += " = nullptr";
-			}
+			else if (p.isOptional)
+				m_typesHeaderFileContent += " = {}";
+
 
 			m_typesHeaderFileContent += ";\n";
 


### PR DESCRIPTION
When warnings are On, some compilers complain about fields not being initialized when using compound literals for construction. This commit should fix that by providing a default initializer for all optional fields.

This can be reproduced by building with gcc on linux and the `missing-field-initializers` warning turned on.

With this PR, the following code won't raise any warning:
```cpp
lsp::CompletionItem item{
    .label = "MyCompletionItem",
    .kind  = lsp::CompletionItemKind::Variable,
};
```

Previously, to not raise any warning, you would have needed to write the following:
```cpp
lsp::CompletionItem item{};
item.label = "MyCompletionItem";
item.kind  = lsp::CompletionItemKind::Variable;
```

**P.S.** The changes I've made don't need to be licensed under my name, I'll leave ownership to the repo owner. Leaving this here because I know some people take this stuff seriously.
