### PR TITLE
[json] Fixed \\" escaping the double quote character in string literals

### DIFF
--- a/lsp/json/json.cpp
+++ b/lsp/json/json.cpp
@@ -232,14 +232,6 @@ private:
 
 		const char* stringStart = ++m_pos;
 
-		// while(*m_pos != '\"' || m_pos[-1] == '\\') does not work
-		// Consider the following string: "\\"
-		// "\\"
-		//  ^ *m_pos != '\"'
-		//   ^ *m_pos != '\"'
-		//    ^ m_pos[-1] == '\"'
-		//     ^ Here we get out of bounds and the string was not closed.
-
 		bool escaping = false;
 		while(*m_pos != '\"' || escaping)
 		{

--- a/lsp/json/json.cpp
+++ b/lsp/json/json.cpp
@@ -232,8 +232,22 @@ private:
 
 		const char* stringStart = ++m_pos;
 
-		while(*m_pos != '\"' || m_pos[-1] == '\\')
+		// while(*m_pos != '\"' || m_pos[-1] == '\\') does not work
+		// Consider the following string: "\\"
+		// "\\"
+		//  ^ *m_pos != '\"'
+		//   ^ *m_pos != '\"'
+		//    ^ m_pos[-1] == '\"'
+		//     ^ Here we get out of bounds and the string was not closed.
+
+		bool escaping = false;
+		while(*m_pos != '\"' || escaping)
 		{
+			if (!escaping && *m_pos == '\\')
+				escaping = true;
+			else // Already escaping or no '\'
+				escaping = false;
+
 			++m_pos;
 
 			if(m_pos >= m_end || *m_pos == '\n')


### PR DESCRIPTION
Previously any string literal that ended with `\\"` was being parsed incorrectly by the json parser.

Since `textDocument/didChange` may also be sent for single characters, receiving the string `"\\"` is very common. Therefore the server may crash often.

This PR makes a very small change to prevent that. See the comments in the modified file for more info.

An example of `textDocument/didChange` message from VSCode that would've thrown without these changes:
```json
{
  "textDocument": {
    "uri": "file:///...",
    "version": 53
  },
  "contentChanges": [{
    "range": {
      "start": { "line": 19, "character": 0 },
      "end":   { "line": 19, "character": 0 }
    },
    "rangeLength": 0,
    "text": "\\"
  }]
}
```

**P.S.** As with my previous pull request, I assign ownership of these changes to the repo owner.