### PR TITLE
[lsp] Fixed usage of undefined behaviour of functions from cctype (and shift operators)

### DIFF
--- a/lsp/fileuri.cpp
+++ b/lsp/fileuri.cpp
@@ -66,7 +66,7 @@ std::string FileURI::decode(std::string_view encoded)
 			const char* start = &encoded[i + 1];
 			const char* end = &encoded[i + 3];
 
-			char c;
+			unsigned char c;
 			const auto [ptr, ec] = std::from_chars(start, end, c, 16);
 
 			if(ec != std::errc{} || ptr != end)

--- a/lsp/fileuri.cpp
+++ b/lsp/fileuri.cpp
@@ -37,9 +37,9 @@ std::string FileURI::encode(std::string_view decoded)
 	std::string encoded;
 	encoded.reserve(decoded.size());
 
-	for(const char c : decoded)
+	for(const unsigned char c : decoded)
 	{
-		if(std::isalnum(static_cast<unsigned char>(c)) || c == '/' || c == '_')
+		if(std::isalnum(c) || c == '/' || c == '_')
 		{
 			encoded.push_back(c);
 		}

--- a/lsp/fileuri.cpp
+++ b/lsp/fileuri.cpp
@@ -39,7 +39,7 @@ std::string FileURI::encode(std::string_view decoded)
 
 	for(const char c : decoded)
 	{
-		if(std::isalnum(c) || c == '/' || c == '_')
+		if(std::isalnum(static_cast<unsigned char>(c)) || c == '/' || c == '_')
 		{
 			encoded.push_back(c);
 		}

--- a/lsp/str.cpp
+++ b/lsp/str.cpp
@@ -8,13 +8,13 @@ namespace lsp::str{
 
 std::string_view trimViewLeft(std::string_view str)
 {
-	str.remove_prefix(std::distance(str.begin(), std::find_if(str.begin(), str.end(), [](char c){ return !std::isspace(c); })));
+	str.remove_prefix(std::distance(str.begin(), std::find_if(str.begin(), str.end(), [](char c){ return !std::isspace(static_cast<unsigned char>(c)); })));
 	return str;
 }
 
 std::string_view trimViewRight(std::string_view str)
 {
-	str.remove_suffix(std::distance(str.rbegin(), std::find_if(str.rbegin(), str.rend(), [](char c){ return !std::isspace(c); })));
+	str.remove_suffix(std::distance(str.rbegin(), std::find_if(str.rbegin(), str.rend(), [](char c){ return !std::isspace(static_cast<unsigned char>(c)); })));
 	return str;
 }
 
@@ -32,7 +32,7 @@ std::string trimLeft(std::string_view str)
 std::string trimLeft(std::string&& str)
 {
 	auto trimmed = std::move(str);
-	trimmed.erase(trimmed.begin(), std::find_if(trimmed.begin(), trimmed.end(), [](char c){ return !std::isspace(c); }));
+	trimmed.erase(trimmed.begin(), std::find_if(trimmed.begin(), trimmed.end(), [](char c){ return !std::isspace(static_cast<unsigned char>(c)); }));
 	return trimmed;
 }
 
@@ -44,7 +44,7 @@ std::string trimRight(std::string_view str)
 std::string trimRight(std::string&& str)
 {
 	auto trimmed = std::move(str);
-	trimmed.erase(std::find_if(trimmed.rbegin(), trimmed.rend(), [](char c){ return !std::isspace(c); }).base(), trimmed.end());
+	trimmed.erase(std::find_if(trimmed.rbegin(), trimmed.rend(), [](char c){ return !std::isspace(static_cast<unsigned char>(c)); }).base(), trimmed.end());
 	return trimmed;
 }
 
@@ -97,7 +97,7 @@ std::string lower(std::string_view str)
 {
 	std::string result;
 	result.reserve(str.size());
-	std::transform(str.begin(), str.end(), std::back_inserter(result), [](char c){ return static_cast<char>(std::tolower(c)); });
+	std::transform(str.begin(), str.end(), std::back_inserter(result), [](char c){ return static_cast<char>(std::tolower(static_cast<unsigned char>(c))); });
 	return result;
 }
 
@@ -105,7 +105,7 @@ std::string upper(std::string_view str)
 {
 	std::string result;
 	result.reserve(str.size());
-	std::transform(str.begin(), str.end(), std::back_inserter(result), [](char c){ return static_cast<char>(std::toupper(c)); });
+	std::transform(str.begin(), str.end(), std::back_inserter(result), [](char c){ return static_cast<char>(std::toupper(static_cast<unsigned char>(c))); });
 	return result;
 }
 

--- a/lsp/str.h
+++ b/lsp/str.h
@@ -31,7 +31,7 @@ struct CaseInsensitiveHash{
 	{
 		std::string upper;
 		upper.reserve(str.size());
-		std::transform(str.cbegin(), str.cend(), std::back_inserter(upper), [](char c){ return static_cast<char>(std::toupper(c)); });
+		std::transform(str.cbegin(), str.cend(), std::back_inserter(upper), [](char c){ return static_cast<char>(std::toupper(static_cast<unsigned char>(c))); });
 		return std::hash<std::string>{}(upper);
 	}
 


### PR DESCRIPTION
I've found that the lsp's `str` module relied on undefined behaviour from functions within the cctype header.

I discovered this because `lsp::FileURI`'s constructor was triggering an assertion (`c >= -1 && c <= 255` from the Visual Studio 2022 compiler) within `std::isspace` when a non-ascii character was found within the string (specifically the `è` unicode character).

Looking at the [documentation of `isspace`](https://en.cppreference.com/w/cpp/string/byte/isspace) it is stated that the behaviour of functions from cctype is undefined for values that are not representable as `unsigned char` which is the case for negative numbers (except -1 which is EOF). Moreover, on the same doc page, it's recommended to cast any `signed char` to an `unsigned char`.

Furthermore, with UTF8 encoded characters there was the risk of accessing out of bounds memory within `FileURI::encode` when escaping a non alpha-numeric character (the behaviour of the shift operator for negative integers is undefined, so an arithmetic shift is likely to occur. I hate the C standard).

I hope I didn't miss anything, I did a find on the whole project for the `char` keyword and both `<<`, `>>`.

**P.S.** As with my previous pull requests, I assign ownership of these changes to the repo owner.