### PR TITLE
[lsp] Fix incorrect encoding when serializing FileURI and incorrect asynchronous response handling

### DIFF
--- a/lsp/fileuri.cpp
+++ b/lsp/fileuri.cpp
@@ -12,8 +12,12 @@ namespace lsp{
 std::string FileURI::toString() const
 {
 #ifdef _WIN32
-	if(std::filesystem::path{m_path}.is_absolute())
-		return Scheme + '/' + encode(m_path);
+	std::filesystem::path path{m_path};
+	if(path.is_absolute())
+	{
+		std::u8string u8Path = path.u8string();
+		return Scheme + '/' + encode(std::string_view{reinterpret_cast<const char*>(u8Path.data()), u8Path.size()});
+	}
 #endif
 
 	return Scheme + encode(m_path);


### PR DESCRIPTION
I meet some problems when i using this lsp framework. It hindered my development and I had to make changes to keep my development going.

Firstly, when i develop a language using multi-thread handlers and return with asynchronous response, I found it always loses several responses. After i look up the source, an obvious mistake is shown there. When the asyncResponseThread handle the async response, it handled the first founded unhandled request correctly, but erase all responses between this and the end of container include other unhandled requets. So I made some small adjustments, and then it worked fine,

Another problem is that I attempt to handle the textDocument/documentLink, it worked well when the all paths only contains English letters, but when some path contains chinese characters, He will cause the client to be unable to jump normally. This is definitely an encoding issue. I try to converted the path to utf-8 encoded, but sometimes it will cause std::filesystem::path to fail to construct properly. So I can only change the source.

In addition, I have a question and suggestion. Since the c++20 standard is supported, why not use std::u8string instead of std::string? Most std::string encodings are not uniform, which will cause various problems.