### PR TITLE
Fix for missing return statement and toJson not being defined

### DIFF
--- a/lsp/enumeration.h
+++ b/lsp/enumeration.h
@@ -22,7 +22,7 @@ public:
 	Enumeration(EnumType index) : m_index{index}{}
 	explicit Enumeration(ValueType&& value){ *this = value; }
 
-	Enumeration& operator=(EnumType other){ m_index = other; }
+	Enumeration& operator=(EnumType other){ m_index = other; return *this; }
 
 	Enumeration& operator=(ValueType&& other)
 	{

--- a/lsp/messagehandler.h
+++ b/lsp/messagehandler.h
@@ -11,6 +11,7 @@
 #include <lsp/threadpool.h>
 #include <lsp/messagebase.h>
 #include <lsp/requestresult.h>
+#include <lsp/serialization.h>
 #include <lsp/jsonrpc/jsonrpc.h>
 
 namespace lsp{


### PR DESCRIPTION
When building the project on Linux, `g++` complained about `Enumeration::operator=` not having a return statement (which is indeed true) and `toJson` not being defined within `messagehandler.inl`. This PR fixes that.

I'd also like to point out an issue I had while building with VS2022 on Windows: `gai_strerror` is a macro which switches between `gai_strerrorA` and `gai_strerrorW`, the latter returns a pointer to `wchar_t` which breaks concatenation with `std::string` within error messages. See https://github.com/Marco4413/cpp-lsp-framework/commit/168003ab2956bef8b50f9fb62f0134e3d3d0f121 for how I fixed it. It's not in this PR because I don't know if `gai_strerrorA` always returns a valid message even if `UNICODE` is defined.