### PR TITLE
fix: hardening fixes for GCC 13/14 -Werror and BSD support

### DIFF
--- a/lsp/io/socket.cpp
+++ b/lsp/io/socket.cpp
@@ -143,7 +143,14 @@ struct Socket::Impl{
 		addrinfo* addrInfoList = nullptr;
 
 		if(auto status = getaddrinfo(address.c_str(), std::to_string(port).c_str(), &hints, &addrInfoList); status != 0)
-			throwError("getaddrinfo: " + std::to_string(status));
+		{
+#ifdef LSP_SOCKET_POSIX
+			const char* statusMsg = gai_strerror(status);
+#else
+			const char* statusMsg = "getaddrinfo failed";
+#endif
+			throwError(std::string("getaddrinfo failed: ") + statusMsg + " (" + std::to_string(status) + ")");
+		}
 
 		for(const auto* addr = addrInfoList; addr; addr = addr->ai_next)
 		{
@@ -198,7 +205,7 @@ struct Socket::Impl{
 			if(bytesRead <= 0)
 				throwError("Failed to read from socket");
 
-			totalBytesRead += bytesRead;
+			totalBytesRead += static_cast<SizeType>(bytesRead);
 		}
 	}
 
@@ -219,7 +226,7 @@ struct Socket::Impl{
 			if(bytesWritten <= 0)
 				throwError("Failed to write to socket");
 
-			totalBytesWritten += bytesWritten;
+			totalBytesWritten += static_cast<SizeType>(bytesWritten);
 		}
 	}
 };

--- a/lsp/jsonrpc/jsonrpc.cpp
+++ b/lsp/jsonrpc/jsonrpc.cpp
@@ -174,6 +174,12 @@ json::Object messageToJson(Message&& message)
 	return json;
 }
 
+// GCC 13/14 false-positive -Wmaybe-uninitialized on std::variant internals
+// when pushing json::Value into a vector.  GCC bugzilla #106247.
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 json::Array messageBatchToJson(MessageBatch&& batch)
 {
 	auto json = json::Array();
@@ -184,6 +190,9 @@ json::Array messageBatchToJson(MessageBatch&& batch)
 
 	return json;
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 Request createRequest(MessageId id, std::string_view method, std::optional<json::Value> params)
 {

--- a/lsp/process.cpp
+++ b/lsp/process.cpp
@@ -90,7 +90,7 @@ struct Process::Impl final : public io::Stream{
 			execvp(file, argv);
 
 			const auto error = errno;
-			::write(errPipe[1], &error, sizeof(error));
+			auto written [[maybe_unused]] = ::write(errPipe[1], &error, sizeof(error));
 
 			close(errPipe[1]);
 
@@ -199,6 +199,11 @@ struct Process::Impl final : public io::Stream{
 				throw io::Error(std::string("Failed to read from process stdout: ") + strerror(errno));
 			}
 
+			if(bytesRead == 0)
+			{
+				throw io::Error("Unexpected EOF while reading from process stdout");
+			}
+
 			totalBytesRead += static_cast<std::size_t>(bytesRead);
 		}
 	}
@@ -216,7 +221,15 @@ struct Process::Impl final : public io::Stream{
 				if(errno == EINTR)
 					continue;
 
+				if(errno == EPIPE)
+					throw io::Error("Failed to write to process stdin: broken pipe");
+
 				throw io::Error(std::string("Failed to write to process stdin: ") + strerror(errno));
+			}
+
+			if(bytesWritten == 0)
+			{
+				throw io::Error("Failed to write to process stdin: wrote 0 bytes");
 			}
 
 			totalBytesWritten += static_cast<std::size_t>(bytesWritten);

--- a/lsp/serialization.h
+++ b/lsp/serialization.h
@@ -21,7 +21,7 @@ namespace lsp{
 inline json::Value toJson(std::nullptr_t){ return {}; }
 inline json::Value toJson(bool v){ return v; }
 inline json::Value toJson(int i){ return i; }
-inline json::Value toJson(float i){ return i; }
+inline json::Value toJson(float i){ return static_cast<double>(i); }
 inline json::Value toJson(double i){ return i; }
 inline json::Value toJson(std::string&& v){ return std::move(v); }
 inline json::Value toJson(const std::string& v){ return json::String{v}; }
@@ -289,13 +289,14 @@ bool canDeserializeTupleFromJson(const json::Array& array)
 
 	using T = std::tuple_element_t<Index, TupleType>;
 
-	if(canDeserializeTypeFromJson<T>(array[Index]))
-		return true;
+	// All tuple elements must be deserializable; fail fast on first mismatch.
+	if(!canDeserializeTypeFromJson<T>(array[Index]))
+		return false;
 
 	if constexpr(Index + 1 < std::tuple_size_v<TupleType>)
 		return canDeserializeTupleFromJson<Index + 1, TupleType>(array);
 	else
-		return false;
+		return true;
 }
 
 template<std::size_t Index, typename VariantType>


### PR DESCRIPTION
- socket.cpp: cast ssize_t → SizeType to silence -Wconversion; use gai_strerror for better getaddrinfo error messages on POSIX
- jsonrpc.cpp: suppress GCC false-positive -Wmaybe-uninitialized on std::variant internals (GCC bugzilla #106247)
- process.cpp: consume ::write() return value with [[maybe_unused]]; handle EOF and EPIPE in read/write loops; cast ssize_t → size_t
- serialization.h: cast float→double to silence -Wdouble-promotion; fix canDeserializeTupleFromJson logic (all elements must match, not short-circuit on first match)

https://claude.ai/code/session_01EwPJWrYwU4Q4FC4QApUBK3