### PR TITLE
Enabling haiku-os to use connection/socket and debug logging

### DIFF
--- a/lsp/connection.cpp
+++ b/lsp/connection.cpp
@@ -41,7 +41,7 @@ void debugLogMessageJson([[maybe_unused]] const std::string& messageType, [[mayb
 	os_log_debug(OS_LOG_DEFAULT, "%{public}s", (messageType + ": " + lsp::json::stringify(json, true)).c_str());
 #elif defined(_WIN32)
 	OutputDebugStringA((messageType + ": " + lsp::json::stringify(json, true) + '\n').c_str());
-#elif defined(__linux__) || defined(__haiku__)
+#elif defined(__linux__) || defined(__HAIKU__)
     fprintf(stderr, "%s\n",  (messageType + ": " + lsp::json::stringify(json, true)).c_str());
 #endif
 }

--- a/lsp/connection.cpp
+++ b/lsp/connection.cpp
@@ -41,6 +41,8 @@ void debugLogMessageJson([[maybe_unused]] const std::string& messageType, [[mayb
 	os_log_debug(OS_LOG_DEFAULT, "%{public}s", (messageType + ": " + lsp::json::stringify(json, true)).c_str());
 #elif defined(_WIN32)
 	OutputDebugStringA((messageType + ": " + lsp::json::stringify(json, true) + '\n').c_str());
+#elif defined(__linux__) || defined(__haiku__)
+    fprintf(stderr, "%s\n",  (messageType + ": " + lsp::json::stringify(json, true)).c_str());
 #endif
 }
 #endif

--- a/lsp/io/socket.h
+++ b/lsp/io/socket.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(__APPLE__) || defined(__linux__)
+#if defined(__APPLE__) || defined(__linux__) || defined(__HAIKU__)
 	#define LSP_SOCKET_POSIX
 #elif defined(_WIN32)
 	#define LSP_SOCKET_WIN32

--- a/lsp/process.h
+++ b/lsp/process.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(__APPLE__) || defined(__linux__)
+#if defined(__APPLE__) || defined(__linux__) || defined(__HAIKU__)
 	#define LSP_PROCESS_POSIX
 #elif defined(_WIN32)
 	#define LSP_PROCESS_WIN32


### PR DESCRIPTION
This change allows the library to fully support the Haiku operating system.